### PR TITLE
[v1.0.1-rc1] gameplay refactor: Changed ludicrous speed trigger

### DIFF
--- a/godot_project/scripts/autoloads/State.gd
+++ b/godot_project/scripts/autoloads/State.gd
@@ -148,7 +148,7 @@ var game = {
 				"active" : true
 			},
 			{
-				"value": 8000,
+				"value": 20000,
 				"log" : "You are approaching ludicrous speeds!",
 				"effects" : null,
 				"active" : true


### PR DESCRIPTION
Changed the value that the ludicrous speed event triggers at, it triggers too fast after the speed + upgrade is purchased.